### PR TITLE
feat: allow additional iam principals

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ No Modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| additional_iam_principals | Additional IAM Principals to allow key management | `list(string)` | `[]` | no |
 | description | n/a | `string` | `"A KMS key used to encrypt Kinesis stream records at-rest."` | no |
 | key\_deletion\_window\_in\_days | Duration in days after which the key is deleted after destruction of the resource, must be between 7 and 30 days. | `string` | `30` | no |
 | name | The display name of the alias. The name must start with the word "alias" followed by a forward slash (alias/). | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -44,13 +44,16 @@ data "aws_iam_policy_document" "kinesis" {
     effect = "Allow"
     principals {
       type = "AWS"
-      identifiers = [
-        format(
-          "arn:%s:iam::%s:root",
-          data.aws_partition.current.partition,
-          data.aws_caller_identity.current.account_id
-        )
-      ]
+      identifiers = concat(
+        [
+          format(
+            "arn:%s:iam::%s:root",
+            data.aws_partition.current.partition,
+            data.aws_caller_identity.current.account_id
+          )
+        ],
+        var.additional_iam_principals,
+      )
     }
     resources = ["*"]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "additional_iam_principals" {
+  type        = list(string)
+  description = "Additional IAM Principals to allow key management"
+  default     = []
+}
+
 variable "description" {
   type        = string
   description = ""


### PR DESCRIPTION
When using an assumed role for managing resources, the role needs access
to the key explicitly via the `Enable IAM User Permissions` sid.